### PR TITLE
Able to edit task due date

### DIFF
--- a/src/api/useUpdateTask.ts
+++ b/src/api/useUpdateTask.ts
@@ -4,7 +4,7 @@ import { queryClient } from './queryClient';
 import type { Task, Tasks } from './types';
 
 type UpdateTaskArgs = Pick<Task, 'id'> &
-    Partial<Pick<Task, 'name' | 'due_date' | 'description'>>;
+    Partial<Pick<Task, 'name' | 'description' | 'due_date'>>;
 
 const useUpdateTask = () => {
     return useMutation<unknown, unknown, UpdateTaskArgs>({

--- a/src/components/Icons/TrashIcon.tsx
+++ b/src/components/Icons/TrashIcon.tsx
@@ -1,9 +1,16 @@
 import { Path, Svg } from 'react-native-svg';
+import { colors } from '../../theme';
 import type { IconProps } from './IconProps';
 
 const TrashIcon: React.FC<IconProps> = (props) => {
     return (
-        <Svg width="24" height="24" viewBox="0 0 24 24" {...props}>
+        <Svg
+            fill={colors.icon}
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            {...props}
+        >
             <Path d="M21 6h-5V4.33A2.42 2.42 0 0 0 13.5 2h-3A2.42 2.42 0 0 0 8 4.33V6H3a1 1 0 0 0 0 2h1v11a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V8h1a1 1 0 0 0 0-2zM10 4.33c0-.16.21-.33.5-.33h3c.29 0 .5.17.5.33V6h-4zM18 19a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V8h12z" />
         </Svg>
     );

--- a/src/components/TaskDueDate/TaskDueDate.tsx
+++ b/src/components/TaskDueDate/TaskDueDate.tsx
@@ -17,10 +17,19 @@ export type TaskDueDateProps = {
      * If `true`, the text color will be default
      */
     defaultColorText?: boolean;
+    /**
+     * Don't render the component if no due date is provided
+     */
+    hideIfNoDueDate?: boolean;
 };
 
 const TaskDueDate: React.FC<TaskDueDateProps> = (props) => {
-    const { dueDate, size = 'md', defaultColorText = false } = props;
+    const {
+        dueDate,
+        size = 'md',
+        defaultColorText = false,
+        hideIfNoDueDate = false,
+    } = props;
     const timestampInfo = getTimestampInfo(dueDate);
 
     const iconSize = size === 'md' ? 17 : 24;
@@ -28,7 +37,7 @@ const TaskDueDate: React.FC<TaskDueDateProps> = (props) => {
     const fontColor = defaultColorText ? undefined : timestampInfo?.color;
     const textMarginLeft = size === 'md' ? spacing(1) : spacing(2);
 
-    if (!timestampInfo) {
+    if (!dueDate && hideIfNoDueDate) {
         return null;
     }
 

--- a/src/components/TaskItem/TaskItem.tsx
+++ b/src/components/TaskItem/TaskItem.tsx
@@ -36,7 +36,7 @@ const TaskItem: React.FC<TaskItemProps> = (props) => {
                     </MyText>
                 )}
                 <View style={styles.taskSubInfo}>
-                    <TaskDueDate dueDate={task.due_date} />
+                    <TaskDueDate hideIfNoDueDate dueDate={task.due_date} />
                 </View>
             </View>
             <Divider />

--- a/src/routes/CreateTaskModal.tsx
+++ b/src/routes/CreateTaskModal.tsx
@@ -1,7 +1,7 @@
 import DateTimePicker, {
     DatePickerOptions,
 } from '@react-native-community/datetimepicker';
-import { useMemo, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import {
     Modal,
     ModalProps,
@@ -11,10 +11,11 @@ import {
     View,
 } from 'react-native';
 import { useCreateTask } from '../api/useCreateTask';
-import { Backdrop, Divider, MyText } from '../components';
-import { CalendarIcon, SendIcon, TrashIcon } from '../components/Icons';
+import { Backdrop, Divider } from '../components';
+import { SendIcon, TrashIcon } from '../components/Icons';
+import { TaskDueDate } from '../components/TaskDueDate';
 import { colors, spacing } from '../theme';
-import { getDateTimestamp, getTimestampInfo } from '../utils/dateTime';
+import { getDateTimestamp } from '../utils/dateTime';
 
 export type CreateTaskModalProps = {
     /**
@@ -35,17 +36,6 @@ const CreateTaskModal: React.FC<CreateTaskModalProps> = (props) => {
     const saveDisabled = taskName.length === 0;
 
     const { mutate } = useCreateTask();
-
-    const dateInfo: ReturnType<typeof getTimestampInfo> = useMemo(() => {
-        if (noDate || !date) {
-            return {
-                label: 'Due Date',
-                color: colors.date.future,
-            };
-        }
-
-        return getTimestampInfo(getDateTimestamp(date));
-    }, [noDate, date]);
 
     const onShowModal = () => {
         setTimeout(() => {
@@ -115,19 +105,11 @@ const CreateTaskModal: React.FC<CreateTaskModalProps> = (props) => {
                                 style={styles.dueDateBtn}
                                 onPress={() => setShowDatePicker(true)}
                             >
-                                <CalendarIcon
-                                    width="16"
-                                    height="16"
-                                    fill={dateInfo?.color}
+                                <TaskDueDate
+                                    dueDate={
+                                        noDate ? null : getDateTimestamp(date)
+                                    }
                                 />
-                                <MyText
-                                    style={{
-                                        marginLeft: spacing(1),
-                                        color: dateInfo?.color,
-                                    }}
-                                >
-                                    {dateInfo?.label}
-                                </MyText>
                             </Pressable>
 
                             {!noDate && (
@@ -135,11 +117,7 @@ const CreateTaskModal: React.FC<CreateTaskModalProps> = (props) => {
                                     style={styles.deleteButton}
                                     onPress={handleDateDelete}
                                 >
-                                    <TrashIcon
-                                        width="20"
-                                        height="20"
-                                        fill={colors.icon}
-                                    />
+                                    <TrashIcon width="20" height="20" />
                                 </Pressable>
                             )}
                         </View>

--- a/src/utils/dateTime.ts
+++ b/src/utils/dateTime.ts
@@ -9,9 +9,9 @@ import { colors } from '../theme';
  */
 export const getTimestampInfo = (
     unixTimestamp: number | null
-): { label: string; color: string } | null => {
+): { label: string; color: string } => {
     if (!unixTimestamp) {
-        return null;
+        return { label: 'Due Date', color: colors.date.future };
     }
 
     const dayjsObj = dayjs.unix(unixTimestamp);
@@ -62,7 +62,11 @@ export const getTimestampInfo = (
  * @param date
  * @returns
  */
-export const getDateTimestamp = (date: Date) => {
+export const getDateTimestamp = (date: Date | null): number | null => {
+    if (!date) {
+        return null;
+    }
+
     return Math.floor(date.valueOf() / 1000);
 };
 


### PR DESCRIPTION
Closes #11 

Checklist: 
- [x] When pressing a task and opening the view task modal, we should be able to press the task due date to open the calendar to change the due date
- [x] If dismissing the calendar without saving, the due date should not be altered;
- [x] Add a small trash can button icon to delete existing due dates (only show if the task has a due date)